### PR TITLE
Fix rounding errors in percentage-based expense splits

### DIFF
--- a/backend/src/services/split_calculator.py
+++ b/backend/src/services/split_calculator.py
@@ -55,11 +55,19 @@ def calculate_portions(expense: Expense) -> Dict[str, float]:
     if expense.split_type == SPLIT_PERCENTAGE:
         if not expense.split_values:
             raise ValueError(ERROR_NO_SPLIT_VALUES)
-        result: Dict[str, float] = {}
+        portions: Dict[str, Decimal] = {}
         for uid, pct in expense.split_values.items():
             portion = (amount * Decimal(str(pct))) / PERCENTAGE_BASE
-            result[uid] = float(_round(portion))
-        return result
+            portions[uid] = _round(portion)
+
+        diff = amount - sum(portions.values())
+        if abs(diff) > Decimal("0"):
+            # Deterministically assign remainder to last non-payer user
+            user_ids = list(portions.keys())
+            candidates = [uid for uid in user_ids if uid != expense.paid_by] or user_ids
+            last = candidates[-1]
+            portions[last] = _round(portions[last] + diff)
+        return {uid: float(v) for uid, v in portions.items()}
 
     raise ValueError(f"{ERROR_INVALID_SPLIT_TYPE}: {expense.split_type}")
 

--- a/backend/tests/test_split_calculator.py
+++ b/backend/tests/test_split_calculator.py
@@ -1,0 +1,41 @@
+import unittest
+from datetime import datetime
+from decimal import Decimal
+
+from src.models.expense import Expense
+from src.services.split_calculator import calculate_portions
+
+
+def make_base_expense(**overrides):
+    """Helper to create a default expense for testing."""
+    data = dict(
+        id="e1",
+        amount=10.0,
+        description="Test Expense",
+        paid_by="u1",
+        split_among=["u1", "u2", "u3"],
+        created_by="u1",
+        split_type="EQUAL",
+        split_values={},
+        created_at=datetime.now(),
+        installments_count=1,
+    )
+    data.update(overrides)
+    return Expense(**data)
+
+
+class TestSplitCalculator(unittest.TestCase):
+    def test_percentage_split_remainder(self):
+        """Test that percentage splits with rounding errors are handled correctly."""
+        expense = make_base_expense(
+            amount=10.00,
+            split_type="PERCENTAGE",
+            split_among=["u1", "u2", "u3"],
+            split_values={"u1": 33.33, "u2": 33.33, "u3": 33.34},
+        )
+
+        portions = calculate_portions(expense)
+        self.assertEqual(sum(portions.values()), expense.amount)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
When an expense is split by percentage, rounding the individual portions could lead to a total that does not match the original expense amount.

This change corrects the issue by calculating the remainder after rounding and distributing it to one of the participants, ensuring the sum of the portions always equals the total expense.

A new test case has been added to verify the fix.