### PR TITLE
Fix README health URL, guard balances for missing payer, and convert groups API test to TestClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ O backend serve o build (se existente) em `/app`.
 
 ---
 
-## � Scripts Unificados
+## 🛠 Scripts Unificados
 
 Windows (PowerShell):
 ```powershell
@@ -381,7 +381,7 @@ Acesse: http://localhost:8000
 ### Endpoints principais
 
 - **Aplicação React**: `http://localhost:8000/` (SPA principal)
-- **API Health Check**: `http://localhost:8000/api/healthz`
+- **API Health Check**: `http://localhost:8000/healthz`
 - **API Endpoints**: `http://localhost:8000/api/*`
 
 ## Desenvolvimento

--- a/backend/src/services/expense_service.py
+++ b/backend/src/services/expense_service.py
@@ -218,6 +218,14 @@ class ExpenseService:
             user.balance.clear()
 
         for exp in group.expenses:
+            if exp.paid_by not in group.members:
+                logger.warning(
+                    "Skipping expense %s for missing payer %s in group %s",
+                    exp.id,
+                    exp.paid_by,
+                    group.id,
+                )
+                continue
             payer = group.members[exp.paid_by]
             portions: Dict[str, float] = calculate_portions(exp)
 

--- a/backend/tests/test_groups_api.py
+++ b/backend/tests/test_groups_api.py
@@ -1,79 +1,32 @@
 #!/usr/bin/env python3
-"""Test script to verify the API returns correct group data."""
-
-import requests
-import json
-
-BASE_URL = "http://127.0.0.1:8000/api"
+"""Tests to verify the API returns correct group data."""
 
 
-def test_groups_api_response():
-    """Test if the groups API returns correct expense association."""
+def test_groups_api_response(client, unique_email):
+    """Ensure group listing includes newly created groups for the signed-in user."""
+    signup_payload = {
+        "name": "Test User",
+        "email": unique_email,
+        "password": "testpass123",
+    }
+    signup_response = client.post("/api/signup", json=signup_payload)
+    assert signup_response.status_code == 201
+    user_id = signup_response.json()["user_id"]
 
-    print("=== Groups API Response Test ===\n")
+    csrf_response = client.get("/api/csrf-token")
+    assert csrf_response.status_code == 200
+    csrf_token = csrf_response.json()["csrf_token"]
 
-    # Start the backend server first if not running
-    print("Testing if backend is running...")
-    try:
-        health_response = requests.get("http://127.0.0.1:8000/healthz", timeout=5)
-        if health_response.status_code == 200:
-            print("✅ Backend is running")
-        else:
-            print("❌ Backend not responding properly")
-            return
-    except Exception as e:
-        print("❌ Backend not running - please start with: uvicorn web_app:app --reload")
-        return
+    group_payload = {"name": "Test Group", "member_ids": [], "member_emails": []}
+    create_response = client.post(
+        "/api/groups", json=group_payload, headers={"X-CSRF-Token": csrf_token}
+    )
+    assert create_response.status_code == 201
 
-    # Create a session for authentication
-    session = requests.Session()
+    groups_response = client.get("/api/groups")
+    assert groups_response.status_code == 200
+    groups = groups_response.json()
+    assert any(group["name"] == "Test Group" for group in groups)
 
-    # Login with existing user
-    print("\n1. Logging in...")
-    login_data = {"email": "testuser@example.com", "password": "testpass123"}
-
-    try:
-        login_response = session.post(f"{BASE_URL}/login", json=login_data)
-        if login_response.status_code == 200:
-            print("   ✅ Login successful")
-        else:
-            print(f"   ❌ Login failed: {login_response.status_code} - {login_response.text}")
-            return
-    except Exception as e:
-        print(f"   ❌ Login error: {e}")
-        return
-
-    # Get all groups
-    print("\n2. Fetching groups...")
-    try:
-        groups_response = session.get(f"{BASE_URL}/groups")
-        if groups_response.status_code == 200:
-            groups = groups_response.json()
-            print(f"   ✅ Retrieved {len(groups)} groups")
-
-            print("\n3. Group details:")
-            for i, group in enumerate(groups):
-                print(f"   Group {i+1}: {group['name']} (ID: {group['id'][:8]}...)")
-                print(f"     Members: {len(group.get('members', {}))}")
-                print(f"     Expenses: {len(group.get('expenses', []))}")
-
-                if group.get("expenses"):
-                    print("     Expense details:")
-                    for j, expense in enumerate(group["expenses"]):
-                        print(f"       {j+1}. {expense['description']} - ${expense['amount']}")
-                print()
-        else:
-            print(
-                f"   ❌ Failed to get groups: {groups_response.status_code} - {groups_response.text}"
-            )
-            return
-
-    except Exception as e:
-        print(f"   ❌ Groups API error: {e}")
-        return
-
-    print("=== API Test completed ===")
-
-
-if __name__ == "__main__":
-    test_groups_api_response()
+    created_group = next(group for group in groups if group["name"] == "Test Group")
+    assert user_id in created_group.get("members", {})


### PR DESCRIPTION
### Motivation
- Fix documentation encoding and an incorrect health-check URL so docs match the running app.
- Prevent runtime errors when recomputing group balances if an expense references a payer who is no longer a group member.
- Replace a manual integration-style groups test that depended on a running server with a unit-style test using the FastAPI `TestClient` and CSRF flow.

### Description
- Updated `README.md` to fix the section title encoding and change the health check reference to `http://localhost:8000/healthz` so it matches the app routes.
- Added a guard in `recompute_group_balances` in `backend/src/services/expense_service.py` to log and skip expenses whose `paid_by` id is not present in `group.members`.
- Rewrote `backend/tests/test_groups_api.py` to use pytest fixtures `client` and `unique_email`, perform signup, fetch `GET /api/csrf-token`, create a group with `POST /api/groups` using the `X-CSRF-Token` header, and assert the created group contains the test user.
- Minor commit message and project bookkeeping reflecting the three-file change set.

### Testing
- No automated tests were executed as part of this change (no `pytest` run in the rollout).
- The updated test `backend/tests/test_groups_api.py` is written to run under `pytest` with the existing `client` and `unique_email` fixtures and should be validated by running `pytest -q`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966c6f579f0832cb1df76b9691571b4)