### PR TITLE
🧹 Refactor duplicated split calculation logic in ExpenseService

### DIFF
--- a/backend/src/services/expense_service.py
+++ b/backend/src/services/expense_service.py
@@ -262,16 +262,7 @@ class ExpenseService:
 
         for exp in group.expenses:
             # Determine portions per user
-            portions: Dict[str, float] = {}
-            if exp.split_type == "EQUAL":
-                per_person = exp.amount / len(exp.split_among)
-                for uid in exp.split_among:
-                    portions[uid] = per_person
-            elif exp.split_type == "EXACT":
-                portions = dict(exp.split_values)
-            elif exp.split_type == "PERCENTAGE":
-                for uid, pct in exp.split_values.items():
-                    portions[uid] = (exp.amount * pct) / 100.0
+            portions: Dict[str, float] = calculate_portions(exp)
 
             if exp.installments_count > 1 and exp.installments:
                 total = exp.amount


### PR DESCRIPTION
This PR addresses a code health issue where the expense splitting logic was duplicated in the `compute_monthly_analysis` method of the `ExpenseService`. By replacing this duplicated logic with a call to the centralized `calculate_portions` function from `split_calculator.py`, we improve maintainability and ensure that splitting calculations are consistent throughout the backend.

🎯 **What:** Replaced manual split calculation in `ExpenseService.compute_monthly_analysis` with `calculate_portions(exp)`.
💡 **Why:** Reduces code duplication, improves maintainability, and ensures consistent handling of rounding differences.
✅ **Verification:** 
- Created and ran a reproduction script (`reproduce_issue.py`) with standard split cases.
- Added a specific test case for rounding discrepancies to verify improved accuracy.
- Ran existing `test_split_calculator.py` to ensure no regressions.
✨ **Result:** Cleaner, more maintainable code with improved precision in monthly analysis.

---
*PR created automatically by Jules for task [13173856117310906414](https://jules.google.com/task/13173856117310906414) started by @BaiduAV*