### PR TITLE
🔒 [security fix] Set SESSION_COOKIE_SECURE to true by default

### DIFF
--- a/backend/src/settings.py
+++ b/backend/src/settings.py
@@ -20,7 +20,7 @@ class Settings:
     DEFAULT_LOCALE: str = os.getenv("DEFAULT_LOCALE", "pt-BR")
     # Security / cookies
     SESSION_COOKIE_SAMESITE: str = os.getenv("SESSION_COOKIE_SAMESITE", "lax")
-    SESSION_COOKIE_SECURE: bool = os.getenv("SESSION_COOKIE_SECURE", "false").lower() in {"1", "true", "yes", "on"}
+    SESSION_COOKIE_SECURE: bool = os.getenv("SESSION_COOKIE_SECURE", "true").lower() in {"1", "true", "yes", "on"}
     AUDIT_LOG_FILE: str = os.getenv("AUDIT_LOG_FILE", "audit.log")
 
 


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is the insecure default configuration of the session cookie secure flag.
⚠️ **Risk:** If left unfixed, session cookies could be sent over unencrypted HTTP connections, making them vulnerable to interception by attackers (e.g., via Man-in-the-Middle attacks).
🛡️ **Solution:** Changed the default value of `SESSION_COOKIE_SECURE` in `backend/src/settings.py` to `True`. This ensures the 'Secure' attribute is added to session cookies by default.

---
*PR created automatically by Jules for task [10064409006471167653](https://jules.google.com/task/10064409006471167653) started by @BaiduAV*