### PR TITLE
⚡ Optimize Group loading by fixing N+1 queries in expenses

### DIFF
--- a/backend/benchmark_nplus1.py
+++ b/backend/benchmark_nplus1.py
@@ -1,0 +1,103 @@
+import sys
+import os
+import time
+import uuid
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+
+# Add backend directory to path to allow imports from src
+sys.path.append(os.path.join(os.getcwd(), "backend"))
+
+from src.database import SessionLocal, Base, engine, UserDB, GroupDB, ExpenseDB, InstallmentDB
+from src.repositories.group_repository import GroupRepository
+
+# Counter for queries
+query_count = 0
+
+@event.listens_for(Engine, "before_cursor_execute")
+def before_cursor_execute(conn, cursor, statement, parameters, context, executemany):
+    global query_count
+    query_count += 1
+
+def setup_benchmark_data(db, num_expenses=50):
+    # Create a test user
+    user_id = str(uuid.uuid4())
+    user = UserDB(id=user_id, name="Test User", email=f"test_{user_id}@example.com")
+    db.add(user)
+
+    # Create a group
+    group_id = str(uuid.uuid4())
+    group = GroupDB(id=group_id, name="Benchmark Group")
+    group.members.append(user)
+    db.add(group)
+
+    db.flush() # Ensure group and user are in DB
+
+    # Add expenses
+    for i in range(num_expenses):
+        expense_id = str(uuid.uuid4())
+        expense = ExpenseDB(
+            id=expense_id,
+            description=f"Expense {i}",
+            amount=100.0,
+            paid_by=user_id,
+            group_id=group_id,
+            split_type="EQUAL",
+            created_at=time.strftime('%Y-%m-%d %H:%M:%S') # use a string for sqlite if needed, but datetime.utcnow is default
+        )
+        db.add(expense)
+        expense.split_among_users.append(user)
+
+        # Add an installment
+        installment = InstallmentDB(
+            id=str(uuid.uuid4()),
+            expense_id=expense_id,
+            number=1,
+            amount=100.0,
+            due_date=time.strftime('%Y-%m-%d %H:%M:%S'),
+            paid=False
+        )
+        db.add(installment)
+
+    db.commit()
+    return group_id
+
+def run_benchmark(num_expenses=50):
+    global query_count
+    db = SessionLocal()
+    try:
+        # Create tables
+        Base.metadata.create_all(bind=engine)
+
+        group_id = setup_benchmark_data(db, num_expenses)
+
+        # Start a new session to ensure nothing is cached
+        db.close()
+        db = SessionLocal()
+
+        # Reset query count
+        query_count = 0
+        start_time = time.time()
+
+        # Act
+        repo = GroupRepository(db)
+        group = repo.get_by_id(group_id)
+
+        # Also test get_all which might be used
+        # repo.get_all()
+
+        end_time = time.time()
+
+        print(f"Loaded group with {len(group.expenses)} expenses")
+        print(f"Time taken: {end_time - start_time:.4f} seconds")
+        print(f"Number of queries: {query_count}")
+
+        return query_count, end_time - start_time
+    finally:
+        db.close()
+
+if __name__ == "__main__":
+    num_exp = 100
+    if len(sys.argv) > 1:
+        num_exp = int(sys.argv[1])
+    run_benchmark(num_exp)

--- a/backend/src/repositories/group_repository.py
+++ b/backend/src/repositories/group_repository.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 
 from sqlalchemy.orm import Session, selectinload
 
-from src.database import GroupDB, UserDB
+from src.database import ExpenseDB, GroupDB, UserDB
 from src.models.group import Group
 from src.models.user import User
 
@@ -31,7 +31,11 @@ class GroupRepository:
         """Get group by ID with all relationships loaded."""
         db_group = (
             self.db.query(GroupDB)
-            .options(selectinload(GroupDB.members), selectinload(GroupDB.expenses))
+            .options(
+                selectinload(GroupDB.members),
+                selectinload(GroupDB.expenses).selectinload(ExpenseDB.installments),
+                selectinload(GroupDB.expenses).selectinload(ExpenseDB.split_among_users),
+            )
             .filter(GroupDB.id == group_id)
             .first()
         )
@@ -41,7 +45,11 @@ class GroupRepository:
         """Get all groups with relationships loaded."""
         db_groups = (
             self.db.query(GroupDB)
-            .options(selectinload(GroupDB.members), selectinload(GroupDB.expenses))
+            .options(
+                selectinload(GroupDB.members),
+                selectinload(GroupDB.expenses).selectinload(ExpenseDB.installments),
+                selectinload(GroupDB.expenses).selectinload(ExpenseDB.split_among_users),
+            )
             .all()
         )
         return [self._to_domain_model(db_group) for db_group in db_groups]


### PR DESCRIPTION
💡 **What:** The optimization implemented nested eager loading (selectinload) for expense relationships when fetching groups.
🎯 **Why:** Previously, loading a group with many expenses would trigger two additional queries per expense (one for installments, one for split_among_users) during domain model conversion. For 100 expenses, this resulted in over 200 queries.
📊 **Measured Improvement:** While environmental limitations (missing dependencies/no internet) prevented running the benchmark script, the optimization reduces the query complexity from O(N) to O(1) additional queries for relationships across all expenses in a group. This is a standard and highly effective fix for the N+1 query problem in SQLAlchemy.

---
*PR created automatically by Jules for task [3361456919812795173](https://jules.google.com/task/3361456919812795173) started by @BaiduAV*